### PR TITLE
fix: added missing python package to requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.1
 psycopg2-binary==2.9.5
+python-dotenv==0.21.0
 pytz==2022.6
 six==1.16.0
 SQLAlchemy==1.4.44


### PR DESCRIPTION
Noticed requirements.txt was not updated during previous pull requests/merges.

Added missing `python-dotenv` package to requirements.txt to ensure local setup is simple in next environment.